### PR TITLE
Add frame support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -34,6 +34,23 @@
         ],
         "console": "integratedTerminal",
         "internalConsoleOptions": "neverOpen"
-    }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Test",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": [
+          "--exit",
+          "--timeout",
+          "999999",
+          "--colors",
+          "--require",
+          "vis-dev-utils/babel-register",
+          "${workspaceFolder}/test"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+  }
   ]
 }

--- a/docs/graph2d/index.html
+++ b/docs/graph2d/index.html
@@ -867,6 +867,7 @@ function (option, path) {
       <pre class="prettyprint lang-js">{
   minorLabels: {
     millisecond:'SSS',
+    frame:      'SSS',
     second:     's',
     minute:     'HH:mm',
     hour:       'HH:mm',
@@ -878,6 +879,7 @@ function (option, path) {
   },
   majorLabels: {
     millisecond:'HH:mm:ss',
+    frame:      'HH:mm:ss,
     second:     'D MMMM HH:mm',
     minute:     'ddd D MMMM',
     hour:       'ddd D MMMM',

--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -640,6 +640,7 @@ function (option, path) {
       <pre class="prettyprint lang-js">{
   minorLabels: {
     millisecond:'SSS',
+    frame:      'SSS',
     second:     's',
     minute:     'HH:mm',
     hour:       'HH:mm',
@@ -651,6 +652,7 @@ function (option, path) {
   },
   majorLabels: {
     millisecond:'HH:mm:ss',
+    frame:      'HH:mm:ss',
     second:     'D MMMM HH:mm',
     minute:     'ddd D MMMM',
     hour:       'ddd D MMMM',

--- a/lib/timeline/Graph2d.js
+++ b/lib/timeline/Graph2d.js
@@ -367,6 +367,45 @@ Graph2d.prototype.getEventProperties = function (event) {
 };
 
 /**
+   * Convert a datetime (Date object) into a position on the screen
+   * @param {Date}   time A date
+   * @return {int}   x    The position on the screen in pixels which corresponds
+   *                      with the given date.
+   */
+Graph2d.prototype.toScreen = function (time) {
+  return this.body.util.toScreen(time)
+};
+
+/**
+ * Convert a datetime (Date object) into a position on the root
+ * This is used to get the pixel density estimate for the screen, not the center panel
+ * @param {Date}   time A date
+ * @return {int}   x    The position on root in pixels which corresponds
+ *                      with the given date.
+ */
+Graph2d.prototype.toGlobalScreen = function (time) {
+  return this.body.util.toGlobalScreen(time)
+};
+
+/**
+ * Convert a position on screen (pixels) to a datetime
+ * @param {int}     x    Position on the screen in pixels
+ * @return {Date}   time The datetime the corresponds with given position x
+ */
+Graph2d.prototype.toTime = function (x) {
+  return this.body.util.toTime(x)
+};
+
+/**
+ * Convert a position on the global screen (pixels) to a datetime
+ * @param {int}     x    Position on the screen in pixels
+ * @return {Date}   time The datetime the corresponds with given position x
+ */
+Graph2d.prototype.toGlobalTime = function (x) {
+  return this.body.util.toGlobalTime(x)
+};
+
+/**
  * Load a configurator
  * @return {Object}
  * @private

--- a/lib/timeline/Graph2d.js
+++ b/lib/timeline/Graph2d.js
@@ -81,6 +81,10 @@ function Graph2d (container, items, groups, options) {
       getStep() {
         return me.timeAxis.step.step;
       },
+      getMillisecondsPerFrame() {
+        return me.timeAxis.step.millisecondsPerFrame;
+      },
+
 
       toScreen: me._toScreen.bind(me),
       toGlobalScreen: me._toGlobalScreen.bind(me), // this refers to the root.width

--- a/lib/timeline/TimeStep.js
+++ b/lib/timeline/TimeStep.js
@@ -17,7 +17,7 @@ import util from '../util';
  * can iterate from the start date to the end date via next(). You can check if
  * the end date is reached with the function hasNext(). After each step, you can
  * retrieve the current date via getCurrent().
- * The TimeStep has scales ranging from milliseconds, seconds, minutes, hours,
+ * The TimeStep has scales ranging from milliseconds, frames, seconds, minutes, hours,
  * days, to years.
  *
  * Version: 1.2
@@ -30,7 +30,7 @@ class TimeStep {
     * @param {Date} [end]           The end date
     * @param {number} [minimumStep] Optional. Minimum step size in milliseconds
     * @param {Date|Array.<Date>} [hiddenDates] Optional.
-    * @param {{showMajorLabels: boolean, showWeekScale: boolean}} [options] Optional.
+    * @param {{showMajorLabels: boolean, showWeekScale: boolean, showFrameScale: boolean, minimumScale: string}} [options] Optional.
     * @constructor  TimeStep
     */
   constructor(start, end, minimumStep, hiddenDates, options) {
@@ -39,12 +39,14 @@ class TimeStep {
 
     // variables
     this.current = this.moment();
+    this._currentDecimal = 0.0;
     this._start = this.moment();
     this._end = this.moment();
 
     this.autoScale  = true;
     this.scale = 'day';
     this.step = 1;
+    this.millisecondsPerFrame = this.options.millisecondsPerFrame || 1000.0/25.0;
 
     // initialize the range
     this.setRange(start, end, minimumStep);
@@ -75,7 +77,8 @@ class TimeStep {
     this.moment = moment;
 
     // update the date properties, can have a new utcOffset
-    this.current = this.moment(this.current.valueOf());
+    this._currentDecimal = this.current.valueOf();
+    this.current = this.moment(this._currentDecimal);
     this._start = this.moment(this._start.valueOf());
     this._end = this.moment(this._end.valueOf());
   }
@@ -83,7 +86,7 @@ class TimeStep {
   /**
    * Set custom formatting for the minor an major labels of the TimeStep.
    * Both `minorLabels` and `majorLabels` are an Object with properties:
-   * 'millisecond', 'second', 'minute', 'hour', 'weekday', 'day', 'week', 'month', 'year'.
+   * 'millisecond', 'frame', 'second', 'minute', 'hour', 'weekday', 'day', 'week', 'month', 'year'.
    * @param {{minorLabels: Object, majorLabels: Object}} format
    */
   setFormat(format) {
@@ -119,6 +122,7 @@ class TimeStep {
    */
   start() {
     this.current = this._start.clone();
+    this._currentDecimal = this.current.valueOf();
     this.roundToMinor();
   }
 
@@ -127,6 +131,8 @@ class TimeStep {
    * This must be executed once when the current date is set to start Date
    */
   roundToMinor() {
+    const mspf = this.options.millisecondsPerFrame;
+
     // round to floor
     // to prevent year & month scales rounding down to the first day of week we perform this separately
     if (this.scale == 'week') {
@@ -145,14 +151,22 @@ class TimeStep {
       case 'hour':         this.current.minutes(0);       // eslint-disable-line no-fallthrough
       case 'minute':       this.current.seconds(0);       // eslint-disable-line no-fallthrough
       case 'second':       this.current.milliseconds(0);  // eslint-disable-line no-fallthrough
+      case 'frame':        this._currentDecimal = Math.floor(this.current.valueOf() / mspf) * mspf; // eslint-disable-line no-fallthrough
+                          this.current.milliseconds(Math.floor(this.current.milliseconds() / mspf) * mspf);
       //case 'millisecond': // nothing to do for milliseconds
     }
 
     if (this.step != 1) {
       // round down to the first minor value that is a multiple of the current step size
       let  priorCurrent = this.current.clone();
-      switch (this.scale) {        
+      switch (this.scale) {
         case 'millisecond':  this.current.subtract(this.current.milliseconds() % this.step, 'milliseconds');  break;
+        case 'frame': {
+          const offset = Math.floor(this.current.milliseconds() / mspf) * mspf % this.step
+          this._currentDecimal -= offset
+          this.current.subtract(offset, 'milliseconds');
+          break;
+        }
         case 'second':       this.current.subtract(this.current.seconds() % this.step, 'seconds'); break;
         case 'minute':       this.current.subtract(this.current.minutes() % this.step, 'minutes'); break;
         case 'hour':         this.current.subtract(this.current.hours() % this.step, 'hours'); break;
@@ -165,6 +179,7 @@ class TimeStep {
       }
       if (!priorCurrent.isSame(this.current)) {
           this.current = this.moment(DateUtil.snapAwayFromHidden(this.hiddenDates, this.current.valueOf(), -1, true));
+          this._currentDecimal = this.current.valueOf();
       }
     }
   }
@@ -181,12 +196,31 @@ class TimeStep {
    * Do the next step
    */
   next() {
+    /**
+     *
+     * @param {number} value
+     * @param {number} precision
+     * @returns {number}
+     */
+    const roundDecimals = (value, precision = 6) => {
+      const v = Math.pow(10, precision)
+      return Math.round(value * v) / v
+    }
+
     const prev = this.current.valueOf();
+    const prevDecimal = this._currentDecimal;
+    const mspf = this.options.millisecondsPerFrame;
 
     // Two cases, needed to prevent issues with switching daylight savings
     // (end of March and end of October)
     switch (this.scale) {
       case 'millisecond':  this.current.add(this.step, 'millisecond'); break;
+      case 'frame': {
+        const offset = this.step * mspf
+        this._currentDecimal = roundDecimals(this._currentDecimal + offset)
+        this.current.add(offset, 'millisecond');
+        break;
+      }
       case 'second':       this.current.add(this.step, 'second'); break;
       case 'minute':       this.current.add(this.step, 'minute'); break;
       case 'hour':
@@ -228,6 +262,12 @@ class TimeStep {
       // round down to the correct major value
       switch (this.scale) {
         case 'millisecond':  if(this.current.milliseconds() > 0 && this.current.milliseconds() < this.step) this.current.milliseconds(0);  break;
+        case 'frame': {
+          if(this._currentDecimal > 0 && this._currentDecimal < this.step * mspf) {
+            this.current.milliseconds(0);
+          }
+          break;
+        }
         case 'second':       if(this.current.seconds() > 0 && this.current.seconds() < this.step) this.current.seconds(0);  break;
         case 'minute':       if(this.current.minutes() > 0 && this.current.minutes() < this.step) this.current.minutes(0); break;
         case 'hour':         if(this.current.hours() > 0 && this.current.hours() < this.step) this.current.hours(0);  break;
@@ -241,7 +281,7 @@ class TimeStep {
     }
 
     // safety mechanism: if current time is still unchanged, move to the end
-    if (this.current.valueOf() == prev) {
+    if (this.current.valueOf() == prev || (this.scale === 'frame' && this._currentDecimal == prevDecimal)) {
       this.current = this._end.clone();
     }
 
@@ -258,7 +298,11 @@ class TimeStep {
    * @return {Moment}  current The current date
    */
   getCurrent() {
-    return this.current.clone();
+    if (this.scale === 'frame') {
+      return this.moment(this._currentDecimal);
+    } else {
+      return this.current.clone();
+    }
   }
 
   /**
@@ -266,17 +310,19 @@ class TimeStep {
    * For example setScale('minute', 5) will result
    * in minor steps of 5 minutes, and major steps of an hour.
    *
-   * @param {{scale: string, step: number}} params
+   * @param {{scale: string, step: number, millisecondsPerFrame: number}} params
    *                               An object containing two properties:
-   *                               - A string 'scale'. Choose from 'millisecond', 'second',
+   *                               - A string 'scale'. Choose from 'millisecond', 'frame', 'second',
    *                                 'minute', 'hour', 'weekday', 'day', 'week', 'month', 'year'.
    *                               - A number 'step'. A step size, by default 1.
    *                                 Choose for example 1, 2, 5, or 10.
+   *                               - A number 'millisecondsPerFrame'. Milliseconds that last one frame.
    */
   setScale(params) {
     if (params && typeof params.scale == 'string') {
       this.scale = params.scale;
       this.step = params.step > 0 ? params.step : 1;
+      this.millisecondsPerFrame = params.millisecondsPerFrame;
       this.autoScale = false;
     }
   }
@@ -298,6 +344,8 @@ class TimeStep {
       return;
     }
 
+    const minimumScale = this.options.minimumScale;
+    const mspf = this.options.millisecondsPerFrame;
     //var b = asc + ds;
 
     const stepYear       = (1000 * 60 * 60 * 24 * 30 * 12);
@@ -306,6 +354,7 @@ class TimeStep {
     const stepHour       = (1000 * 60 * 60);
     const stepMinute     = (1000 * 60);
     const stepSecond     = (1000);
+    const stepFrame      = (mspf);
     const stepMillisecond= (1);
 
     // find the smallest step that is larger than the provided minimumStep
@@ -316,22 +365,33 @@ class TimeStep {
     if (stepYear*10 > minimumStep)          {this.scale = 'year';        this.step = 10;}
     if (stepYear*5 > minimumStep)           {this.scale = 'year';        this.step = 5;}
     if (stepYear > minimumStep)             {this.scale = 'year';        this.step = 1;}
+    if (minimumScale == 'year')             {return;}
     if (stepMonth*3 > minimumStep)          {this.scale = 'month';       this.step = 3;}
     if (stepMonth > minimumStep)            {this.scale = 'month';       this.step = 1;}
-    if (stepDay*7 > minimumStep && this.options.showWeekScale)            {this.scale = 'week';        this.step = 1;}
+    if (minimumScale == 'month')            {return;}
+    if (stepDay*7 > minimumStep 
+      && this.options.showWeekScale)        {this.scale = 'week';        this.step = 1;}
     if (stepDay*2 > minimumStep)            {this.scale = 'day';         this.step = 2;}
     if (stepDay > minimumStep)              {this.scale = 'day';         this.step = 1;}
+    if (minimumScale == 'day')              {return;}
     if (stepDay/2 > minimumStep)            {this.scale = 'weekday';     this.step = 1;}
+    if (minimumScale == 'weekday')          {return;}
     if (stepHour*4 > minimumStep)           {this.scale = 'hour';        this.step = 4;}
     if (stepHour > minimumStep)             {this.scale = 'hour';        this.step = 1;}
+    if (minimumScale == 'hour')             {return;}
     if (stepMinute*15 > minimumStep)        {this.scale = 'minute';      this.step = 15;}
     if (stepMinute*10 > minimumStep)        {this.scale = 'minute';      this.step = 10;}
     if (stepMinute*5 > minimumStep)         {this.scale = 'minute';      this.step = 5;}
     if (stepMinute > minimumStep)           {this.scale = 'minute';      this.step = 1;}
+    if (minimumScale == 'minute')           {return;}
     if (stepSecond*15 > minimumStep)        {this.scale = 'second';      this.step = 15;}
     if (stepSecond*10 > minimumStep)        {this.scale = 'second';      this.step = 10;}
     if (stepSecond*5 > minimumStep)         {this.scale = 'second';      this.step = 5;}
     if (stepSecond > minimumStep)           {this.scale = 'second';      this.step = 1;}
+    if (minimumScale == 'second')           {return;}
+    if (minimumStep < stepFrame*2
+      && this.options.showFrameScale)       {this.scale = 'frame';       this.step = 1;}
+    if (minimumScale == 'frame')            {return;}
     if (stepMillisecond*200 > minimumStep)  {this.scale = 'millisecond'; this.step = 200;}
     if (stepMillisecond*100 > minimumStep)  {this.scale = 'millisecond'; this.step = 100;}
     if (stepMillisecond*50 > minimumStep)   {this.scale = 'millisecond'; this.step = 50;}
@@ -345,13 +405,15 @@ class TimeStep {
    * The snap intervals are dependent on the current scale and step.
    * Static function
    * @param {Date} date    the date to be snapped.
-   * @param {string} scale Current scale, can be 'millisecond', 'second',
+   * @param {string} scale Current scale, can be 'millisecond', 'frame', 'second',
    *                       'minute', 'hour', 'weekday, 'day', 'week', 'month', 'year'.
    * @param {number} step  Current step (1, 2, 4, 5, ...
+   * @param {number} millisecondsPerFrame Milliseconds that last one frame.
    * @return {Date} snappedDate
    */
-  static snap(date, scale, step) {
+  static snap(date, scale, step, millisecondsPerFrame) {
     const clone = moment(date);
+    const mspf = millisecondsPerFrame;
 
     if (scale == 'year') {
       const year = clone.year() + Math.round(clone.month() / 12);
@@ -456,6 +518,9 @@ class TimeStep {
           clone.milliseconds(Math.round(clone.milliseconds() / 500) * 500); break;
       }
     }
+    else if (scale == 'frame') {
+      clone.milliseconds(Math.floor(Math.round(clone.milliseconds() / mspf) * mspf / step) * step);
+    }
     else if (scale == 'millisecond') {
       const _step = step > 5 ? step / 2 : 1;
       clone.milliseconds(Math.round(clone.milliseconds() / _step) * _step);
@@ -480,6 +545,7 @@ class TimeStep {
         case 'hour':
         case 'minute':
         case 'second':
+        case 'frame':
         case 'millisecond':
           return true;
         default:
@@ -494,6 +560,7 @@ class TimeStep {
         case 'hour':
         case 'minute':
         case 'second':
+        case 'frame':
         case 'millisecond':
           return true;
         default:
@@ -503,6 +570,7 @@ class TimeStep {
     else if (this.switchedDay == true) {
       switch (this.scale) {
         case 'millisecond':
+        case 'frame':
         case 'second':
         case 'minute':
         case 'hour':
@@ -513,9 +581,12 @@ class TimeStep {
     }
 
     const date = this.moment(this.current);
+    const mspf = this.options.millisecondsPerFrame;
     switch (this.scale) {
       case 'millisecond':
         return (date.milliseconds() == 0);
+      case 'frame':
+        return this.options.showFrameScale ? (Math.floor(date.milliseconds() / mspf) == 0) : (date.milliseconds() == 0);
       case 'second':
         return (date.seconds() == 0);
       case 'minute':
@@ -541,9 +612,10 @@ class TimeStep {
    * date and the scale. For example when scale is MINUTE, the current time is
    * formatted as "hh:mm".
    * @param {Date} [date=this.current] custom date. if not provided, current date is taken
+   * @param {number} [width] width in pixels of the current label to decide if render or not
    * @returns {String}
    */
-  getLabelMinor(date) {
+  getLabelMinor(date, width) {
     if (date == undefined) {
       date = this.current;
     }
@@ -552,9 +624,10 @@ class TimeStep {
     }
 
     if (typeof(this.format.minorLabels) === "function") {
-      return this.format.minorLabels(date, this.scale, this.step);
+      return this.format.minorLabels(date, this.scale, this.step, width);
     }
 
+    const mspf = this.options.millisecondsPerFrame;
     const format = this.format.minorLabels[this.scale];
     // noinspection FallThroughInSwitchStatementJS
     switch (this.scale) {
@@ -564,6 +637,15 @@ class TimeStep {
         if(date.date() === 1 && date.weekday() !== 0){
             return "";
         }
+
+      // eslint-disable-next-line no-fallthrough
+      case 'frame':
+        // TODO: Not accurate, frames are repeated. We leave it as is for now
+        // because we're using our own formatter.
+        if (Math.floor(date.milliseconds() / mspf) !== 0) {
+          return Math.floor(date.milliseconds() / mspf)
+        }
+
       default: // eslint-disable-line no-fallthrough
         return (format && format.length > 0) ? this.moment(date).format(format) : '';
     }
@@ -602,6 +684,7 @@ class TimeStep {
     const current = m.locale ? m.locale('en') : m.lang('en'); // old versions of moment have .lang() function
     const step = this.step;
     const classNames = [];
+    const mspf = this.options.millisecondsPerFrame;
 
     /**
      *
@@ -662,6 +745,10 @@ class TimeStep {
         classNames.push(today(current));
         classNames.push(even(current.milliseconds()));
         break;
+      case 'frame':
+        classNames.push(today(current));
+        classNames.push(even(current.milliseconds() * mspf));
+        break;
       case 'second':
         classNames.push(today(current));
         classNames.push(even(current.seconds()));
@@ -714,6 +801,7 @@ class TimeStep {
 TimeStep.FORMAT = {
   minorLabels: {
     millisecond:'SSS',
+    frame:      'SSS',
     second:     's',
     minute:     'HH:mm',
     hour:       'HH:mm',
@@ -725,6 +813,7 @@ TimeStep.FORMAT = {
   },
   majorLabels: {
     millisecond:'HH:mm:ss',
+    frame:      'HH:mm:ss',
     second:     'D MMMM HH:mm',
     minute:     'ddd D MMMM',
     hour:       'ddd D MMMM',

--- a/lib/timeline/Timeline.js
+++ b/lib/timeline/Timeline.js
@@ -749,6 +749,45 @@ export default class Timeline extends Core {
   }
 
   /**
+   * Convert a datetime (Date object) into a position on the screen
+   * @param {Date}   time A date
+   * @return {int}   x    The position on the screen in pixels which corresponds
+   *                      with the given date.
+   */
+  toScreen(time) {
+    return this.body.util.toScreen(time)
+  }
+
+  /**
+   * Convert a datetime (Date object) into a position on the root
+   * This is used to get the pixel density estimate for the screen, not the center panel
+   * @param {Date}   time A date
+   * @return {int}   x    The position on root in pixels which corresponds
+   *                      with the given date.
+   */
+  toGlobalScreen(time) {
+    return this.body.util.toGlobalScreen(time)
+  }
+
+  /**
+   * Convert a position on screen (pixels) to a datetime
+   * @param {int}     x    Position on the screen in pixels
+   * @return {Date}   time The datetime the corresponds with given position x
+   */
+  toTime(x) {
+    return this.body.util.toTime(x)
+  }
+
+  /**
+   * Convert a position on the global screen (pixels) to a datetime
+   * @param {int}     x    Position on the screen in pixels
+   * @return {Date}   time The datetime the corresponds with given position x
+   */
+  toGlobalTime(x) {
+    return this.body.util.toGlobalTime(x)
+  }
+
+  /**
    * Toggle Timeline rolling mode
    */
   toggleRollingMode() {

--- a/lib/timeline/Timeline.js
+++ b/lib/timeline/Timeline.js
@@ -122,6 +122,9 @@ export default class Timeline extends Core {
         getStep() {
           return me.timeAxis.step.step;
         },
+        getMillisecondsPerFrame() {
+          return me.timeAxis.step.millisecondsPerFrame;
+        },
 
         toScreen: me._toScreen.bind(me),
         toGlobalScreen: me._toGlobalScreen.bind(me), // this refers to the root.width
@@ -300,6 +303,22 @@ export default class Timeline extends Core {
           this.setItems(null);            // remove all
           this.setItems(itemsData.rawDS); // add all
           this.setSelection(selection);   // restore selection
+        }
+      }
+    }
+
+    if ('millisecondsPerFrame' in options) {
+      if (this.options) {
+        this.options.millisecondsPerFrame = options.millisecondsPerFrame
+      }
+
+      if (this.timeAxis) {
+        if (this.timeAxis.step) {
+          this.timeAxis.step.millisecondsPerFrame = options.millisecondsPerFrame
+        }
+
+        if (this.timeAxis.options) {
+          this.timeAxis.options.millisecondsPerFrame = options.millisecondsPerFrame
         }
       }
     }
@@ -698,8 +717,9 @@ export default class Timeline extends Core {
     const snap = this.itemSet.options.snap || null;
     const scale = this.body.util.getScale();
     const step = this.body.util.getStep();
+    const mspf = this.body.util.getMillisecondsPerFrame();
     const time = this._toTime(x);
-    const snappedTime = snap ? snap(time, scale, step) : time;
+    const snappedTime = snap ? snap(time, scale, step, mspf) : time;
 
     const element = util.getTarget(event);
     let what = null;

--- a/lib/timeline/component/CustomTime.js
+++ b/lib/timeline/component/CustomTime.js
@@ -267,10 +267,10 @@ class CustomTime extends Component {
 
     const scale = this.body.util.getScale();
     const step = this.body.util.getStep();
+    const mspf = this.body.util.getMillisecondsPerFrame();
     const snap = this.options.snap;
 
-    const snappedTime = snap ? snap(time, scale, step) : time;
-
+    const snappedTime = snap ? snap(time, scale, step, mspf) : time;
     this.setCustomTime(snappedTime);
 
     // fire a timechange event

--- a/lib/timeline/component/DataAxis.js
+++ b/lib/timeline/component/DataAxis.js
@@ -26,6 +26,7 @@ class DataAxis extends Component {
       showMinorLabels: true,
       showMajorLabels: true,
       showWeekScale: false,
+      showFrameScale: false,
       icons: false,
       majorLinesOffset: 7,
       minorLinesOffset: 4,

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -1635,7 +1635,8 @@ class ItemSet extends Component {
     const time = this.body.util.toTime(x);
     const scale = this.body.util.getScale();
     const step = this.body.util.getStep();
-    const start = snap ? snap(time, scale, step) : time;
+    const mspf = this.body.util.getMillisecondsPerFrame();
+    const start = snap ? snap(time, scale, step, mspf) : time;
     const end = start;
 
     const itemData = {
@@ -1700,6 +1701,7 @@ class ItemSet extends Component {
       const xOffset = this.options.rtl ? domRootOffsetLeft + this.body.domProps.right.width : domRootOffsetLeft + this.body.domProps.left.width;
       const scale = this.body.util.getScale();
       const step = this.body.util.getStep();
+      const mspf = this.body.util.getMillisecondsPerFrame();
 
       //only calculate the new group for the item that's actually dragged
       const selectedItem = this.touchParams.selectedItem;
@@ -1752,14 +1754,14 @@ class ItemSet extends Component {
                 initialEnd = util.convert(props.data.end, 'Date');
                 end = new Date(initialEnd.valueOf() + offset);
                 // TODO: pass a Moment instead of a Date to snap(). (Breaking change)
-                itemData.end = snap ? snap(end, scale, step) : end;
+                itemData.end = snap ? snap(end, scale, step, mspf) : end;
               }
             } else {
               if (itemData.start != undefined) {
                 initialStart = util.convert(props.data.start, 'Date');
                 start = new Date(initialStart.valueOf() + offset);
                 // TODO: pass a Moment instead of a Date to snap(). (Breaking change)
-                itemData.start = snap ? snap(start, scale, step) : start;
+                itemData.start = snap ? snap(start, scale, step, mspf) : start;
               }
             }
           }
@@ -1770,14 +1772,14 @@ class ItemSet extends Component {
                 initialStart = util.convert(props.data.start, 'Date');
                 start = new Date(initialStart.valueOf() + offset);
                 // TODO: pass a Moment instead of a Date to snap(). (Breaking change)
-                itemData.start = snap ? snap(start, scale, step) : start;
+                itemData.start = snap ? snap(start, scale, step, mspf) : start;
               }
             } else {
               if (itemData.end != undefined) {
                 initialEnd = util.convert(props.data.end, 'Date');
                 end = new Date(initialEnd.valueOf() + offset);
                 // TODO: pass a Moment instead of a Date to snap(). (Breaking change)
-                itemData.end = snap ? snap(end, scale, step) : end;
+                itemData.end = snap ? snap(end, scale, step, mspf) : end;
               }
             }
           }
@@ -1793,12 +1795,12 @@ class ItemSet extends Component {
                 const duration  = initialEnd.valueOf() - initialStart.valueOf();
 
                 // TODO: pass a Moment instead of a Date to snap(). (Breaking change)
-                itemData.start = snap ? snap(start, scale, step) : start;
+                itemData.start = snap ? snap(start, scale, step, mspf) : start;
                 itemData.end   = new Date(itemData.start.valueOf() + duration);
               }
               else {
                 // TODO: pass a Moment instead of a Date to snap(). (Breaking change)
-                itemData.start = snap ? snap(start, scale, step) : start;
+                itemData.start = snap ? snap(start, scale, step, mspf) : start;
               }
             }
           }
@@ -2397,23 +2399,24 @@ class ItemSet extends Component {
     const start = this.body.util.toTime(x);
     const scale = this.body.util.getScale();
     const step = this.body.util.getStep();
+    const mspf = this.body.util.getMillisecondsPerFrame();
     let end;
 
     let newItemData;
     if (event.type == 'drop') {
       newItemData = JSON.parse(event.dataTransfer.getData("text"));
       newItemData.content = newItemData.content ? newItemData.content : 'new item';
-      newItemData.start = newItemData.start ? newItemData.start : (snap ? snap(start, scale, step) : start);
+      newItemData.start = newItemData.start ? newItemData.start : (snap ? snap(start, scale, step, mspf) : start);
       newItemData.type = newItemData.type || 'box';
       newItemData[this.itemsData.idProp] = newItemData.id || randomUUID();
 
       if (newItemData.type == 'range' && !newItemData.end) {
         end = this.body.util.toTime(x + this.props.width / 5);
-        newItemData.end = snap ? snap(end, scale, step) : end;
+        newItemData.end = snap ? snap(end, scale, step, mspf) : end;
       }
     } else {
       newItemData = {
-        start: snap ? snap(start, scale, step) : start,
+        start: snap ? snap(start, scale, step, mspf) : start,
         content: 'new item'
       };
       newItemData[this.itemsData.idProp] = randomUUID();
@@ -2421,7 +2424,7 @@ class ItemSet extends Component {
       // when default type is a range, add a default end date to the new item
       if (this.options.type === 'range') {
         end = this.body.util.toTime(x + this.props.width / 5);
-        newItemData.end = snap ? snap(end, scale, step) : end;
+        newItemData.end = snap ? snap(end, scale, step, mspf) : end;
       }
     }
 

--- a/lib/timeline/component/TimeAxis.js
+++ b/lib/timeline/component/TimeAxis.js
@@ -44,6 +44,7 @@ class TimeAxis extends Component {
       showMinorLabels: true,
       showMajorLabels: true,
       showWeekScale: false,
+      showFrameScale: false,
       maxMinorChars: 7,
       format: util.extend({}, TimeStep.FORMAT),
       moment,
@@ -75,6 +76,9 @@ class TimeAxis extends Component {
         'showMinorLabels',
         'showMajorLabels',
         'showWeekScale',
+        'showFrameScale',
+        'minimumScale',
+        'millisecondsPerFrame',
         'maxMinorChars',
         'hiddenDates',
         'timeAxis',
@@ -103,6 +107,12 @@ class TimeAxis extends Component {
         }
         else {
           moment.lang(options.locale);
+        }
+      }
+
+      if ('millisecondsPerFrame' in options) {
+        if (this.step) {
+          this.step.millisecondsPerFrame = options.millisecondsPerFrame
         }
       }
     }
@@ -265,7 +275,7 @@ class TimeAxis extends Component {
       }
 
       if (this.options.showMinorLabels && showMinorGrid) {
-        var label = this._repaintMinorText(x, step.getLabelMinor(current), orientation, className);
+        var label = this._repaintMinorText(x, step.getLabelMinor(current, width), orientation, className);
         label.style.width = `${width}px`; // set width to prevent overflow
       }
 

--- a/lib/timeline/optionsGraph2d.js
+++ b/lib/timeline/optionsGraph2d.js
@@ -108,6 +108,7 @@ let allOptions = {
   format: {
     minorLabels: {
       millisecond: {string,'undefined': 'undefined'},
+      frame: {string,'undefined': 'undefined'},
       second: {string,'undefined': 'undefined'},
       minute: {string,'undefined': 'undefined'},
       hour: {string,'undefined': 'undefined'},
@@ -121,6 +122,7 @@ let allOptions = {
     },
     majorLabels: {
       millisecond: {string,'undefined': 'undefined'},
+      frame: {string,'undefined': 'undefined'},
       second: {string,'undefined': 'undefined'},
       minute: {string,'undefined': 'undefined'},
       hour: {string,'undefined': 'undefined'},
@@ -240,6 +242,7 @@ let configureOptions = {
     format: {
       minorLabels: {
         millisecond:'SSS',
+        frame:      'SSS',
         second:     's',
         minute:     'HH:mm',
         hour:       'HH:mm',
@@ -252,6 +255,7 @@ let configureOptions = {
       },
       majorLabels: {
         millisecond:'HH:mm:ss',
+        frame:      'HH:mm:ss',
         second:     'D MMMM HH:mm',
         minute:     'ddd D MMMM',
         hour:       'ddd D MMMM',

--- a/lib/timeline/optionsTimeline.js
+++ b/lib/timeline/optionsTimeline.js
@@ -55,6 +55,7 @@ let allOptions = {
   format: {
     minorLabels: {
       millisecond: {string,'undefined': 'undefined'},
+      frame: {string,'undefined': 'undefined'},
       second: {string,'undefined': 'undefined'},
       minute: {string,'undefined': 'undefined'},
       hour: {string,'undefined': 'undefined'},
@@ -67,6 +68,7 @@ let allOptions = {
     },
     majorLabels: {
       millisecond: {string,'undefined': 'undefined'},
+      frame: {string,'undefined': 'undefined'},
       second: {string,'undefined': 'undefined'},
       minute: {string,'undefined': 'undefined'},
       hour: {string,'undefined': 'undefined'},
@@ -147,6 +149,9 @@ let allOptions = {
   showMajorLabels: { 'boolean': bool},
   showMinorLabels: { 'boolean': bool},
   showWeekScale: { 'boolean': bool},
+  showFrameScale: { 'boolean': bool },
+  minimumScale: { string },
+  millisecondsPerFrame: { 'number': number },
   stack: { 'boolean': bool},
   stackSubgroups: { 'boolean': bool},
   cluster: {
@@ -217,6 +222,7 @@ let configureOptions = {
     format: {
       minorLabels: {
         millisecond:'SSS',
+        frame:      'SSS',
         second:     's',
         minute:     'HH:mm',
         hour:       'HH:mm',
@@ -228,6 +234,7 @@ let configureOptions = {
       },
       majorLabels: {
         millisecond:'HH:mm:ss',
+        frame:      'HH:mm:ss',
         second:     'D MMMM HH:mm',
         minute:     'ddd D MMMM',
         hour:       'ddd D MMMM',
@@ -282,7 +289,7 @@ let configureOptions = {
     start: '',
     //template: {'function': 'function'},
     //timeAxis: {
-    //  scale: ['millisecond', 'second', 'minute', 'hour', 'weekday', 'day', 'week', 'month', 'year'],
+    //  scale: ['millisecond', 'frame', 'second', 'minute', 'hour', 'weekday', 'day', 'week', 'month', 'year'],
     //  step: [1, 1, 10, 1]
     //},
     showTooltips: true,

--- a/package.json
+++ b/package.json
@@ -1,15 +1,27 @@
 {
-  "name": "vis-timeline",
-  "version": "0.0.0-no-version",
+  "name": "@metrica-sports/vis-timeline",
+  "version": "1.0.0",
   "description": "Create a fully customizable, interactive timeline with items and ranges.",
   "homepage": "https://visjs.github.io/vis-timeline/",
   "license": "(Apache-2.0 OR MIT)",
+  "author": {
+    "name": "Metrica Sports",
+    "email": "info@metrica-sports.com"
+  },
   "repository": {
+    "type": "git",
+    "url": "https://github.com/metrica-sports/ngx-scrollbar"
+  },
+  "versionForked": "7.7.2",
+  "repositoryForked": {
     "type": "git",
     "url": "https://github.com/visjs/vis-timeline.git"
   },
   "bugs": {
     "url": "https://github.com/visjs/vis-timeline/issues"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
   },
   "keywords": [
     "vis",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -538,6 +538,10 @@ export class Graph2d {
   setOptions(options: TimelineOptions): void;
   setSelection(ids: IdType | IdType[]): void;
   setWindow(start: DateType, end: DateType, options?: TimelineAnimationOptions): void;
+  toScreen(time: Date): number;
+  toGlobalScreen(time: Date): number;
+  toTime(x: number): Date;
+  toGlobalTime(x: number): Date;
 }
 
 export interface Graph2d {
@@ -705,6 +709,37 @@ export class Timeline {
    * @param callback The callback function
    */
   setWindow(start: DateType, end: DateType, options?: TimelineAnimationOptions, callback?: () => void): void;
+
+  /**
+   * Convert a datetime (Date object) into a position on the screen
+   * @param {Date}   time A date
+   * @return {int}   x    The position on the screen in pixels which corresponds
+   *                      with the given date.
+   */
+  toScreen(time: Date): number;
+
+  /**
+   * Convert a datetime (Date object) into a position on the root
+   * This is used to get the pixel density estimate for the screen, not the center panel
+   * @param {Date}   time A date
+   * @return {int}   x    The position on root in pixels which corresponds
+   *                      with the given date.
+   */
+  toGlobalScreen(time: Date): number;
+
+  /**
+   * Convert a position on screen (pixels) to a datetime
+   * @param {int}     x    Position on the screen in pixels
+   * @return {Date}   time The datetime the corresponds with given position x
+   */
+  toTime(x: number): Date;
+
+  /**
+   * Convert a position on the global screen (pixels) to a datetime
+   * @param {int}     x    Position on the screen in pixels
+   * @return {Date}   time The datetime the corresponds with given position x
+   */
+  toGlobalTime(x: number): Date;
 
   /**
    * Toggle rollingMode.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -39,7 +39,7 @@ export type DateType = Date | number | string;
 export type HeightWidthType = IdType;
 export type TimelineItemType = 'box' | 'point' | 'range' | 'background';
 export type TimelineAlignType = 'auto' | 'center' | 'left' | 'right';
-export type TimelineTimeAxisScaleType = 'millisecond' | 'second' | 'minute' | 'hour' |
+export type TimelineTimeAxisScaleType = 'millisecond' | 'frame' | 'second' | 'minute' | 'hour' |
   'weekday' | 'day' | 'week' | 'month' | 'year';
 export type TimelineEventPropertiesResultWhatType = 'item' | 'background' | 'axis' |
   'group-label' | 'custom-time' | 'current-time';
@@ -144,7 +144,7 @@ export interface TimelineEditableOption {
   overrideItems?: boolean;
 }
 
-export type TimelineFormatLabelsFunction = (date: Date, scale: string, step: number) => string;
+export type TimelineFormatLabelsFunction = (date: Date, scale: string, step: number, width?: number) => string;
 
 export interface TimelineFormatLabelsOption {
   millisecond?: string;
@@ -302,6 +302,9 @@ export interface TimelineOptions {
   showMinorLabels?: boolean;
   showWeekScale?: boolean;
   showTooltips?: boolean;
+  showFrameScale?: boolean;
+  minimumScale?: string;
+  millisecondsPerFrame?: number;
   stack?: boolean;
   stackSubgroups?: boolean;
   snap?: TimelineOptionsSnapType;


### PR DESCRIPTION
# Description
In this pull request, we'll add frame support, so we can use this library with time-codes at any frame-rate. Apart from that, we've exposed time-screen conversion methods to render elements on top of timeline accurately.

# Out of Scope
Minor-label rendering has not been implemented precisely and some frames are repeated when scale is `frame`. We'll leave it as is for now because we're using our own formatter in the application part.