### PR TITLE
Expose group visibility override

### DIFF
--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -148,6 +148,10 @@ class Group {
    * @param {Object} data   Group data, can contain properties content and className
    */
   setData(data) {
+    if(data){
+      this.isVisibleOverride = data.isVisibleOverride !== undefined ? data.isVisibleOverride : null;
+    }
+
     if (this.itemSet.groupTouchParams.isDragging) return;
 
     // update contents

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -33,6 +33,7 @@ class Group {
     this.itemSet = itemSet;
     this.isVisible = null;
     this.stackDirty = true; // if true, items will be restacked on next redraw
+    this.isVisibleOverride = data && data.isVisibleOverride !== undefined ? data.isVisibleOverride : null;
 
     // This is a stack of functions (`() => void`) that will be executed before
     // the instance is disposed off (method `dispose`). Anything that needs to
@@ -604,6 +605,10 @@ class Group {
    * @private
    */
   _isGroupVisible(range, margin) {
+    if(this.isVisibleOverride !== null) {
+      return this.isVisibleOverride
+    }
+    
     return (this.top <= range.body.domProps.centerContainer.height - range.body.domProps.scrollTop + margin.axis)
     && (this.top + this.height + margin.axis >= - range.body.domProps.scrollTop);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metrica-sports/vis-timeline",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Create a fully customizable, interactive timeline with items and ranges.",
   "homepage": "https://visjs.github.io/vis-timeline/",
   "license": "(Apache-2.0 OR MIT)",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -122,6 +122,7 @@ export interface DataGroup {
   visible?: boolean;
   showNested?: boolean;
   subgroupVisibility?: SubGroupVisibilityOptions;
+  isVisibleOverride?: boolean; 
 }
 
 export interface DataGroupOptions {


### PR DESCRIPTION
This PR adds a property, "isVisibleOverride", to the DataGroup element that can override the default show/hide behaviour of groups. This allows groups to be rendered/removed by setting/unsetting this property.
