### PR TITLE
Fix unnecessary group re-renders

### DIFF
--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -519,7 +519,19 @@ class ItemSet extends Component {
    * @param {{refreshItems: boolean}} [options]
    */
   markDirty(options) {
-    this.groupIds = [];
+   if(this.groupsData){ 
+      let groupIds = this.groupsData.getIds({
+        order: this.options.groupOrder
+      });
+      groupIds = this._orderNestedGroups(groupIds);  
+
+      const changed = !util.equalArray(groupIds, this.groupIds);  
+      if(changed){ 
+        this.groupIds = [];
+      }
+    }else{ 
+      this.groupIds = [];
+    } 
 
     if (options) {
       if (options.refreshItems) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metrica-sports/vis-timeline",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Create a fully customizable, interactive timeline with items and ranges.",
   "homepage": "https://visjs.github.io/vis-timeline/",
   "license": "(Apache-2.0 OR MIT)",


### PR DESCRIPTION
This PR checks if groups have changed before clearing them when marking an ItemSet as dirty. Not doing this would cause groups to be hidden and shown again on every setOptions call updating the DOM unnecessarily.